### PR TITLE
feat: enable converting CloudEvent requests to Background Event requests

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Run HTTP conformance tests
       uses: GoogleCloudPlatform/functions-framework-conformance/action@v1.1.1
       with:
-        version: 'v0.3.9'
+        version: 'v1.0.0'
         functionType: 'http'
         useBuildpacks: false
         cmd: "'go run testdata/conformance/cmd/http/main.go'"
@@ -40,9 +40,9 @@ jobs:
     - name: Run event conformance tests
       uses: GoogleCloudPlatform/functions-framework-conformance/action@v1.1.1
       with:
-        version: 'v0.3.9'
+        version: 'v1.0.0'
         functionType: 'legacyevent'
-        validateMapping: false
+        validateMapping: true
         useBuildpacks: false
         cmd: "'go run testdata/conformance/cmd/legacyevent/main.go'"
         startDelay: 5

--- a/funcframework/events_test.go
+++ b/funcframework/events_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/functions/metadata"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
@@ -496,6 +497,411 @@ func TestConvertBackgroundToCloudEventRequest(t *testing.T) {
 
 			if got := req.Header.Get(contentLengthHeader); got != fmt.Sprint(len(gotBody)) {
 				t.Errorf("incorrect request content length header, got %s, want %s", got, fmt.Sprint(len(gotBody)))
+			}
+		})
+	}
+}
+
+func TestConvertCloudEventToBackgroundRequest(t *testing.T) {
+	tcs := []struct {
+		name   string
+		ceJSON string
+		wantBE string
+	}{
+		{
+			name: "pubsub",
+			ceJSON: `{
+				"specversion": "1.0",
+				"type": "google.cloud.pubsub.topic.v1.messagePublished",
+				"source": "//pubsub.googleapis.com/projects/sample-project/topics/gcf-test",
+				"id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+				"time": "2020-09-29T11:32:00.000Z",
+				"datacontenttype": "application/json",
+				"data": {
+				  "subscription": "projects/sample-project/subscriptions/sample-subscription",
+				  "message": {
+					"@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
+					"messageId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+					"publishTime": "2020-09-29T11:32:00.000Z",
+					"attributes": {
+					   "attr1":"attr1-value"
+					},
+					"data": "dGVzdCBtZXNzYWdlIDM="
+				  }
+				}
+			  }`,
+			wantBE: `{
+				"context": {
+				   "eventId":"aaaaaa-1111-bbbb-2222-cccccccccccc",
+				   "timestamp":"2020-09-29T11:32:00.000Z",
+				   "eventType":"google.pubsub.topic.publish",
+				   "resource":{
+					 "service":"pubsub.googleapis.com",
+					 "name":"projects/sample-project/topics/gcf-test",
+					 "type":"type.googleapis.com/google.pubsub.v1.PubsubMessage"
+				   }
+				},
+				"data": {
+				   "@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
+				   "attributes": {
+					  "attr1":"attr1-value"
+				   },
+				   "data": "dGVzdCBtZXNzYWdlIDM="
+				}
+			 }`,
+		},
+		{
+			name: "firebase auth event",
+			ceJSON: `{
+				"specversion": "1.0",
+				"type": "google.firebase.auth.user.v1.created",
+				"source": "//firebaseauth.googleapis.com/projects/my-project-id",
+				"subject": "users/UUpby3s4spZre6kHsgVSPetzQ8l2",
+				"id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+				"time": "2020-09-29T11:32:00.000Z",
+				"datacontenttype": "application/json",
+				"data": {
+				  "email": "test@nowhere.com",
+				  "metadata": {
+					"createTime": "2020-05-26T10:42:27Z",
+					"lastSignInTime": "2020-10-24T11:00:00Z"
+				  },
+				  "providerData": [
+					{
+					  "email": "test@nowhere.com",
+					  "providerId": "password",
+					  "uid": "test@nowhere.com"
+					}
+				  ],
+				  "uid": "UUpby3s4spZre6kHsgVSPetzQ8l2"
+				}
+			  }`,
+			wantBE: `{
+				"data": {
+				  "email": "test@nowhere.com",
+				  "metadata": {
+					"createdAt": "2020-05-26T10:42:27Z",
+					"lastSignedInAt": "2020-10-24T11:00:00Z"
+				  },
+				  "providerData": [
+					{
+					  "email": "test@nowhere.com",
+					  "providerId": "password",
+					  "uid": "test@nowhere.com"
+					}
+				  ],
+				  "uid": "UUpby3s4spZre6kHsgVSPetzQ8l2"
+				},
+				"context": {
+				  "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+				  "eventType": "providers/firebase.auth/eventTypes/user.create",
+				  "resource": "projects/my-project-id",
+				  "timestamp": "2020-09-29T11:32:00.000Z"
+				}
+			  }`,
+		},
+		{
+			name: "firebase db event firebaseio.com domain",
+			ceJSON: `{
+				"specversion": "1.0",
+				"type": "google.firebase.database.ref.v1.written",
+				"source": "//firebasedatabase.googleapis.com/projects/_/locations/us-central1/instances/my-project-id",
+				"subject": "refs/gcf-test/xyz",
+				"id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+				"time": "2020-09-29T11:32:00.000Z",
+				"datacontenttype": "application/json",
+				"data": {
+				  "data": null,
+				  "delta": {
+					"grandchild": "other"
+				  }
+				}
+			  }
+			  `,
+			wantBE: `{
+				"data": {
+				  "data": null,
+				  "delta": {
+					"grandchild": "other"
+				  }
+				},
+				"context": {
+				  "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
+				  "timestamp": "2020-09-29T11:32:00.000Z",
+				  "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+				  "eventType": "providers/google.firebase.database/eventTypes/ref.write" 
+				}
+			  }`,
+		},
+		{
+			name: "firebase db event localized domain",
+			ceJSON: `{
+				"specversion": "1.0",
+				"type": "google.firebase.database.ref.v1.written",
+				"source": "//firebasedatabase.googleapis.com/projects/_/locations/europe-west1/instances/my-project-id",
+				"subject": "refs/gcf-test/xyz",
+				"id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+				"time": "2020-09-29T11:32:00.000Z",
+				"datacontenttype": "application/json",
+				"data": {
+				  "data": {
+					"grandchild": "other"
+				  },
+				  "delta": {
+					"grandchild": "other changed"
+				  }
+				}
+			  }`,
+			wantBE: `{
+				"data": {
+				  "data": {
+					"grandchild": "other"
+				  },
+				  "delta": {
+					"grandchild": "other changed"
+				  }
+				},
+				"context": {
+				  "resource": "projects/_/instances/my-project-id/refs/gcf-test/xyz",
+				  "timestamp": "2020-09-29T11:32:00.000Z",
+				  "eventType": "providers/google.firebase.database/eventTypes/ref.write",
+				  "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc"
+				}
+			  }`,
+		},
+		{
+			name: "cloud storage event",
+			ceJSON: `{
+				"specversion": "1.0",
+				"type": "google.cloud.storage.object.v1.finalized",
+				"source": "//storage.googleapis.com/projects/_/buckets/some-bucket",
+				"subject": "objects/folder/Test.cs",
+				"id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+				"time": "2020-09-29T11:32:00.000Z",
+				"datacontenttype": "application/json",
+				"data": {
+				  "bucket": "some-bucket",
+				  "contentType": "text/plain",
+				  "crc32c": "rTVTeQ==",
+				  "etag": "CNHZkbuF/ugCEAE=",
+				  "generation": "1587627537231057",
+				  "id": "some-bucket/folder/Test.cs/1587627537231057",
+				  "kind": "storage#object",
+				  "md5Hash": "kF8MuJ5+CTJxvyhHS1xzRg==",
+				  "mediaLink": "https://www.googleapis.com/download/storage/v1/b/some-bucket/o/folder%2FTest.cs?generation=1587627537231057\u0026alt=media",
+				  "metageneration": "1",
+				  "name": "folder/Test.cs",
+				  "selfLink": "https://www.googleapis.com/storage/v1/b/some-bucket/o/folder/Test.cs",
+				  "size": "352",
+				  "storageClass": "MULTI_REGIONAL",
+				  "timeCreated": "2020-04-23T07:38:57.230Z",
+				  "timeStorageClassUpdated": "2020-04-23T07:38:57.230Z",
+				  "updated": "2020-04-23T07:38:57.230Z"
+				}
+			  }`,
+			wantBE: `{
+				"context": {
+				   "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+				   "timestamp": "2020-09-29T11:32:00.000Z",
+				   "eventType": "google.storage.object.finalize",
+				   "resource": {
+					  "service": "storage.googleapis.com",
+					  "name": "projects/_/buckets/some-bucket/objects/folder/Test.cs",
+					  "type": "storage#object"
+				   }
+				},
+				"data": {
+				   "bucket": "some-bucket",
+				   "contentType": "text/plain",
+				   "crc32c": "rTVTeQ==",
+				   "etag": "CNHZkbuF/ugCEAE=",
+				   "generation": "1587627537231057",
+				   "id": "some-bucket/folder/Test.cs/1587627537231057",
+				   "kind": "storage#object",
+				   "md5Hash": "kF8MuJ5+CTJxvyhHS1xzRg==",
+				   "mediaLink": "https://www.googleapis.com/download/storage/v1/b/some-bucket/o/folder%2FTest.cs?generation=1587627537231057\u0026alt=media",
+				   "metageneration": "1",
+				   "name": "folder/Test.cs",
+				   "selfLink": "https://www.googleapis.com/storage/v1/b/some-bucket/o/folder/Test.cs",
+				   "size": "352",
+				   "storageClass": "MULTI_REGIONAL",
+				   "timeCreated": "2020-04-23T07:38:57.230Z",
+				   "timeStorageClassUpdated": "2020-04-23T07:38:57.230Z",
+				   "updated": "2020-04-23T07:38:57.230Z"
+				}
+			  }`,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			ce := cloudevents.NewEvent()
+			if err := json.Unmarshal([]byte(tc.ceJSON), &ce); err != nil {
+				t.Fatalf("unable to marshal input CloudEvent JSON: %s, error: %v", tc.ceJSON, err)
+			}
+
+			req, err := http.NewRequest(http.MethodPost, "example.com", bytes.NewBuffer(ce.Data()))
+			if err != nil {
+				t.Fatalf("unable to create test request data: %v", err)
+			}
+
+			req.Header.Set("ce-type", ce.Type())
+			req.Header.Set("ce-source", ce.Source())
+			req.Header.Set("ce-id", ce.ID())
+			req.Header.Set("ce-subject", ce.Subject())
+			req.Header.Set("ce-time", ce.Time().Format(timeFmt))
+			req.Header.Set("ce-specversion", ce.SpecVersion())
+
+			if err := convertCloudEventToBackgroundRequest(req); err != nil {
+				t.Fatalf("unexpected error converting CloudEvent to Background event request: %v", err)
+			}
+
+			gotBody, err := ioutil.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("unable to read got request body: %v", err)
+			}
+
+			// Convert human-readable string into an easily comparable object
+			// so cmp.Diff output is easier to read
+			var wantObj map[string]interface{}
+			if err := json.Unmarshal([]byte(tc.wantBE), &wantObj); err != nil {
+				t.Fatalf("test wantBE is invalid JSON: %q, err: %v", tc.wantBE, err)
+			}
+			var gotObj map[string]interface{}
+			if err := json.Unmarshal(gotBody, &gotObj); err != nil {
+				t.Fatalf("createCloudEventRequest() created invalid JSON: %q, err: %v", string(gotBody), err)
+			}
+
+			if diff := cmp.Diff(wantObj, gotObj); diff != "" {
+				t.Errorf("createCloudEventRequest() mismatch (-want +got):\n%s", diff)
+			}
+
+			if got := req.Header.Get(contentTypeHeader); got != jsonContentType {
+				t.Errorf("incorrect request content type header, got %s, want %s", got, jsonContentType)
+			}
+
+			if got := req.Header.Get(contentLengthHeader); got != fmt.Sprint(len(gotBody)) {
+				t.Errorf("incorrect request content length header, got %s, want %s", got, fmt.Sprint(len(gotBody)))
+			}
+		})
+	}
+}
+
+func TestShouldConvertCloudEventToBackgroundRequest(t *testing.T) {
+	tcs := []struct {
+		name          string
+		ceHeaderJSON  string
+		shouldConvert bool
+	}{
+		{
+			name: "standard",
+			ceHeaderJSON: `{
+				"specversion": "1.0",
+				"type": "google.cloud.storage.object.v1.finalized",
+				"source": "//storage.googleapis.com/projects/_/buckets/some-bucket",
+				"subject": "objects/folder/Test.cs",
+				"id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+				"time": "2020-09-29T11:32:00.000Z",
+				"datacontenttype": "application/json"
+			  }`,
+			shouldConvert: true,
+		},
+		{
+			name: "missing extraneous header ok",
+			ceHeaderJSON: `{
+				"specversion": "1.0",
+				"type": "google.cloud.storage.object.v1.finalized",
+				"source": "//storage.googleapis.com/projects/_/buckets/some-bucket",
+				"subject": "objects/folder/Test.cs",
+				"id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+				"datacontenttype": "application/json"
+			  }`,
+			shouldConvert: true,
+		},
+		{
+			name: "invalid type",
+			ceHeaderJSON: `{
+				"specversion": "1.0",
+				"type": "google.invalid.type",
+				"source": "//storage.googleapis.com/projects/_/buckets/some-bucket",
+				"subject": "objects/folder/Test.cs",
+				"id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+				"time": "2020-09-29T11:32:00.000Z",
+				"datacontenttype": "application/json"
+			  }`,
+			shouldConvert: false,
+		},
+		{
+			name: "missing specversion",
+			ceHeaderJSON: `{
+				"type": "google.cloud.storage.object.v1.finalized",
+				"source": "//storage.googleapis.com/projects/_/buckets/some-bucket",
+				"subject": "objects/folder/Test.cs",
+				"id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+				"time": "2020-09-29T11:32:00.000Z",
+				"datacontenttype": "application/json"
+			  }`,
+			shouldConvert: false,
+		},
+		{
+			name: "missing type",
+			ceHeaderJSON: `{
+				"specversion": "1.0",
+				"source": "//storage.googleapis.com/projects/_/buckets/some-bucket",
+				"subject": "objects/folder/Test.cs",
+				"id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+				"time": "2020-09-29T11:32:00.000Z",
+				"datacontenttype": "application/json"
+			  }`,
+			shouldConvert: false,
+		},
+		{
+			name: "missing source",
+			ceHeaderJSON: `{
+				"specversion": "1.0",
+				"subject": "objects/folder/Test.cs",
+				"id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+				"time": "2020-09-29T11:32:00.000Z",
+				"datacontenttype": "application/json"
+			  }`,
+			shouldConvert: false,
+		},
+		{
+			name: "missing ID",
+			ceHeaderJSON: `{
+				"specversion": "1.0",
+				"type": "google.cloud.storage.object.v1.finalized",
+				"source": "//storage.googleapis.com/projects/_/buckets/some-bucket",
+				"subject": "objects/folder/Test.cs",
+				"time": "2020-09-29T11:32:00.000Z",
+				"datacontenttype": "application/json"
+			  }`,
+			shouldConvert: false,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			var headers map[string]string
+			if err := json.Unmarshal([]byte(tc.ceHeaderJSON), &headers); err != nil {
+				t.Fatalf("unable to marshal input CloudEvent JSON: %s, error: %v", tc.ceHeaderJSON, err)
+			}
+
+			req, err := http.NewRequest(http.MethodPost, "example.com", bytes.NewBufferString(""))
+			if err != nil {
+				t.Fatalf("unable to create test request data: %v", err)
+			}
+
+			req.Header.Set("ce-type", headers["type"])
+			req.Header.Set("ce-source", headers["source"])
+			req.Header.Set("ce-id", headers["id"])
+			req.Header.Set("ce-subject", headers["subject"])
+			req.Header.Set("ce-time", headers["time"])
+			req.Header.Set("ce-specversion", headers["specversion"])
+
+			got := shouldConvertCloudEventToBackgroundRequest(req)
+			if got != tc.shouldConvert {
+				t.Errorf("shouldConvertCloudEventToBackgroundRequest() = %t, want %t", got, tc.shouldConvert)
 			}
 		})
 	}

--- a/funcframework/framework.go
+++ b/funcframework/framework.go
@@ -133,6 +133,12 @@ func registerEventFunction(path string, fn interface{}, h *http.ServeMux) error 
 		}
 		defer recoverPanicHTTP(w, "Function panic")
 
+		if shouldConvertCloudEventToBackgroundRequest(r) {
+			if err := convertCloudEventToBackgroundRequest(r); err != nil {
+				writeHTTPErrorResponse(w, http.StatusBadRequest, crashStatus, fmt.Sprintf("error converting CloudEvent to Background Event: %v", err))
+			}
+		}
+
 		handleEventFunction(w, r, fn)
 	})
 	return nil

--- a/funcframework/framework_test.go
+++ b/funcframework/framework_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestHTTPFunction(t *testing.T) {
@@ -66,7 +67,7 @@ type eventData struct {
 func TestEventFunction(t *testing.T) {
 	var tests = []struct {
 		name      string
-		data      []byte
+		body      []byte
 		fn        interface{}
 		status    int
 		header    string
@@ -74,7 +75,7 @@ func TestEventFunction(t *testing.T) {
 	}{
 		{
 			name: "valid function",
-			data: []byte(`{"id": 12345,"name": "custom"}`),
+			body: []byte(`{"id": 12345,"name": "custom"}`),
 			fn: func(c context.Context, s customStruct) error {
 				if s.ID != 12345 {
 					return fmt.Errorf("expected id=12345, got %d", s.ID)
@@ -89,7 +90,7 @@ func TestEventFunction(t *testing.T) {
 		},
 		{
 			name: "incorrect type",
-			data: []byte(`{"id": 12345,"name": 123}`),
+			body: []byte(`{"id": 12345,"name": 123}`),
 			fn: func(c context.Context, s customStruct) error {
 				return nil
 			},
@@ -98,7 +99,7 @@ func TestEventFunction(t *testing.T) {
 		},
 		{
 			name: "erroring function",
-			data: []byte(`{"id": 12345,"name": "custom"}`),
+			body: []byte(`{"id": 12345,"name": "custom"}`),
 			fn: func(c context.Context, s customStruct) error {
 				return fmt.Errorf("TestEventFunction(erroring function): this error should fire")
 			},
@@ -107,7 +108,7 @@ func TestEventFunction(t *testing.T) {
 		},
 		{
 			name: "pubsub event",
-			data: []byte(`{
+			body: []byte(`{
 				"context": {
 					"eventId": "1234567",
 					"timestamp": "2019-11-04T23:01:10.112Z",
@@ -135,7 +136,7 @@ func TestEventFunction(t *testing.T) {
 		},
 		{
 			name: "pubsub legacy event",
-			data: []byte(`{
+			body: []byte(`{
 				"eventId": "1234567",
 				"timestamp": "2019-11-04T23:01:10.112Z",
 				"eventType": "google.pubsub.topic.publish",
@@ -159,6 +160,74 @@ func TestEventFunction(t *testing.T) {
 			status: http.StatusOK,
 			header: "",
 		},
+		{
+			name: "cloudevent",
+			body: []byte(`{
+				"data": {
+				  "bucket": "some-bucket",
+				  "contentType": "text/plain",
+				  "crc32c": "rTVTeQ==",
+				  "etag": "CNHZkbuF/ugCEAE=",
+				  "generation": "1587627537231057",
+				  "id": "some-bucket/folder/Test.cs/1587627537231057",
+				  "kind": "storage#object",
+				  "md5Hash": "kF8MuJ5+CTJxvyhHS1xzRg==",
+				  "mediaLink": "https://www.googleapis.com/download/storage/v1/b/some-bucket/o/folder%2FTest.cs?generation=1587627537231057\u0026alt=media",
+				  "metageneration": "1",
+				  "name": "folder/Test.cs",
+				  "selfLink": "https://www.googleapis.com/storage/v1/b/some-bucket/o/folder/Test.cs",
+				  "size": "352",
+				  "storageClass": "MULTI_REGIONAL",
+				  "timeCreated": "2020-04-23T07:38:57.230Z",
+				  "timeStorageClassUpdated": "2020-04-23T07:38:57.230Z",
+				  "updated": "2020-04-23T07:38:57.230Z"
+				}
+			  }`),
+			fn: func(c context.Context, gotData map[string]interface{}) error {
+				want := `{
+					"data": {
+					  "bucket": "some-bucket",
+					  "contentType": "text/plain",
+					  "crc32c": "rTVTeQ==",
+					  "etag": "CNHZkbuF/ugCEAE=",
+					  "generation": "1587627537231057",
+					  "id": "some-bucket/folder/Test.cs/1587627537231057",
+					  "kind": "storage#object",
+					  "md5Hash": "kF8MuJ5+CTJxvyhHS1xzRg==",
+					  "mediaLink": "https://www.googleapis.com/download/storage/v1/b/some-bucket/o/folder%2FTest.cs?generation=1587627537231057\u0026alt=media",
+					  "metageneration": "1",
+					  "name": "folder/Test.cs",
+					  "selfLink": "https://www.googleapis.com/storage/v1/b/some-bucket/o/folder/Test.cs",
+					  "size": "352",
+					  "storageClass": "MULTI_REGIONAL",
+					  "timeCreated": "2020-04-23T07:38:57.230Z",
+					  "timeStorageClassUpdated": "2020-04-23T07:38:57.230Z",
+					  "updated": "2020-04-23T07:38:57.230Z"
+					}
+				  }`
+
+				var wantData map[string]interface{}
+				if err := json.Unmarshal([]byte(want), &wantData); err != nil {
+					return fmt.Errorf("unable to unmarshal test data: %s, error: %v", want, err)
+				}
+
+				if diff := cmp.Diff(wantData, gotData); diff != "" {
+					return fmt.Errorf("TestEventFunction() mismatch (-want +got):\n%s", diff)
+				}
+				return nil
+			},
+			status: http.StatusOK,
+			header: "",
+			ceHeaders: map[string]string{
+				"ce-specversion":     "1.0",
+				"ce-type":            "google.cloud.storage.object.v1.finalized",
+				"ce-source":          "//storage.googleapis.com/projects/_/buckets/some-bucket",
+				"ce-subject":         "objects/folder/Test.cs",
+				"ce-id":              "aaaaaa-1111-bbbb-2222-cccccccccccc",
+				"ce-time":            "2020-09-29T11:32:00.000Z",
+				"ce-datacontenttype": "application/json",
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -170,7 +239,10 @@ func TestEventFunction(t *testing.T) {
 		srv := httptest.NewServer(h)
 		defer srv.Close()
 
-		req, err := http.NewRequest("POST", srv.URL, bytes.NewBuffer(tc.data))
+		req, err := http.NewRequest("POST", srv.URL, bytes.NewBuffer(tc.body))
+		if err != nil {
+			t.Fatalf("error creating HTTP request for test: %v", err)
+		}
 		req.Header.Set("Content-Type", "application/json")
 		for k, v := range tc.ceHeaders {
 			req.Header.Set(k, v)
@@ -213,7 +285,7 @@ func TestCloudEventFunction(t *testing.T) {
 
 	var tests = []struct {
 		name      string
-		data      []byte
+		body      []byte
 		fn        func(context.Context, cloudevents.Event) error
 		status    int
 		header    string
@@ -221,7 +293,7 @@ func TestCloudEventFunction(t *testing.T) {
 	}{
 		{
 			name: "binary cloudevent",
-			data: []byte("<much wow=\"xml\"/>"),
+			body: []byte("<much wow=\"xml\"/>"),
 			fn: func(ctx context.Context, e cloudevents.Event) error {
 				if e.String() != testCE.String() {
 					return fmt.Errorf("TestCloudEventFunction(binary cloudevent): got: %v, want: %v", e, testCE)
@@ -243,7 +315,7 @@ func TestCloudEventFunction(t *testing.T) {
 		},
 		{
 			name: "structured cloudevent",
-			data: cloudeventsJSON,
+			body: cloudeventsJSON,
 			fn: func(ctx context.Context, e cloudevents.Event) error {
 				if e.String() != testCE.String() {
 					return fmt.Errorf("TestCloudEventFunction(structured cloudevent): got: %v, want: %v", e, testCE)
@@ -255,6 +327,81 @@ func TestCloudEventFunction(t *testing.T) {
 			ceHeaders: map[string]string{
 				"Content-Type": "application/cloudevents+json",
 			},
+		},
+		{
+			name: "background event",
+			body: []byte(`{
+				"context": {
+				   "eventId": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+				   "timestamp": "2020-09-29T11:32:00.000Z",
+				   "eventType": "google.storage.object.finalize",
+				   "resource": {
+					  "service": "storage.googleapis.com",
+					  "name": "projects/_/buckets/some-bucket/objects/folder/Test.cs",
+					  "type": "storage#object"
+				   }
+				},
+				"data": {
+				   "bucket": "some-bucket",
+				   "contentType": "text/plain",
+				   "crc32c": "rTVTeQ==",
+				   "etag": "CNHZkbuF/ugCEAE=",
+				   "generation": "1587627537231057",
+				   "id": "some-bucket/folder/Test.cs/1587627537231057",
+				   "kind": "storage#object",
+				   "md5Hash": "kF8MuJ5+CTJxvyhHS1xzRg==",
+				   "mediaLink": "https://www.googleapis.com/download/storage/v1/b/some-bucket/o/folder%2FTest.cs?generation=1587627537231057\u0026alt=media",
+				   "metageneration": "1",
+				   "name": "folder/Test.cs",
+				   "selfLink": "https://www.googleapis.com/storage/v1/b/some-bucket/o/folder/Test.cs",
+				   "size": "352",
+				   "storageClass": "MULTI_REGIONAL",
+				   "timeCreated": "2020-04-23T07:38:57.230Z",
+				   "timeStorageClassUpdated": "2020-04-23T07:38:57.230Z",
+				   "updated": "2020-04-23T07:38:57.230Z"
+				}
+			  }`),
+			fn: func(ctx context.Context, e cloudevents.Event) error {
+				want := `{
+					"specversion": "1.0",
+					"type": "google.cloud.storage.object.v1.finalized",
+					"source": "//storage.googleapis.com/projects/_/buckets/some-bucket",
+					"subject": "objects/folder/Test.cs",
+					"id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+					"time": "2020-09-29T11:32:00.000Z",
+					"datacontenttype": "application/json",
+					"data": {
+					  "bucket": "some-bucket",
+					  "contentType": "text/plain",
+					  "crc32c": "rTVTeQ==",
+					  "etag": "CNHZkbuF/ugCEAE=",
+					  "generation": "1587627537231057",
+					  "id": "some-bucket/folder/Test.cs/1587627537231057",
+					  "kind": "storage#object",
+					  "md5Hash": "kF8MuJ5+CTJxvyhHS1xzRg==",
+					  "mediaLink": "https://www.googleapis.com/download/storage/v1/b/some-bucket/o/folder%2FTest.cs?generation=1587627537231057\u0026alt=media",
+					  "metageneration": "1",
+					  "name": "folder/Test.cs",
+					  "selfLink": "https://www.googleapis.com/storage/v1/b/some-bucket/o/folder/Test.cs",
+					  "size": "352",
+					  "storageClass": "MULTI_REGIONAL",
+					  "timeCreated": "2020-04-23T07:38:57.230Z",
+					  "timeStorageClassUpdated": "2020-04-23T07:38:57.230Z",
+					  "updated": "2020-04-23T07:38:57.230Z"
+					}
+				  }`
+				wantCE := cloudevents.NewEvent()
+				err := json.Unmarshal([]byte(want), &wantCE)
+				if err != nil {
+					return fmt.Errorf("error unmarshaling JSON to CloudEvent: %v", err)
+				}
+
+				if e.String() != wantCE.String() {
+					return fmt.Errorf("TestCloudEventFunction got: %s, want: %s", e.String(), wantCE.String())
+				}
+				return nil
+			},
+			status: http.StatusOK,
 		},
 	}
 
@@ -268,7 +415,10 @@ func TestCloudEventFunction(t *testing.T) {
 		srv := httptest.NewServer(h)
 		defer srv.Close()
 
-		req, err := http.NewRequest("POST", srv.URL, bytes.NewBuffer(tc.data))
+		req, err := http.NewRequest("POST", srv.URL, bytes.NewBuffer(tc.body))
+		if err != nil {
+			t.Fatalf("error creating HTTP request for test: %v", err)
+		}
 		for k, v := range tc.ceHeaders {
 			req.Header.Add(k, v)
 		}


### PR DESCRIPTION
This enables backwards compatability for GCF Background Functions with
newer CloudEvent-based eventing systems and brings FF Go up to v1.0.0 of
the conformance tests.